### PR TITLE
Enhance E2E reporting with environment metadata

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -41,6 +41,10 @@ jobs:
         run: npm install
         working-directory: ./e2e
 
+      - name: Run lint check and stop on error
+        run: npm run lint
+        working-directory: ./e2e
+
       - name: Create .env file
         run: cp .env.example .env
         working-directory: ./e2e

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Start Oracle service
         run: ORACLE_PASSWORD=${{ secrets.ORACLE_PASSWORD_SECRET }} docker compose up -d oracle

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -71,7 +71,7 @@ jobs:
           done
 
       - name: Run e2e tests
-        run: docker compose run --rm -e GITHUB_REF=${{ github.event.pull_request.head.ref || github.ref }} -e GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }} e2e npm run test:run-and-report
+        run: docker compose run --rm -e GITHUB_REF=${{ github.event.pull_request.head.ref || github.ref }} -e GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }} -e GITHUB_REPOSITORY=${{ github.repository }} e2e npm run test:run-and-report
 
       - name: Upload report for Github Pages
         if: always()

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,7 +3,6 @@ name: E2E Tests
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -71,7 +71,7 @@ jobs:
           done
 
       - name: Run e2e tests
-        run: docker compose run --rm -e GITHUB_REF=${{ github.ref }} -e GITHUB_SHA=${{ github.sha }} e2e npm run test:run-and-report
+        run: docker compose run --rm -e GITHUB_REF=${{ github.event.pull_request.head.ref || github.ref }} -e GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }} e2e npm run test:run-and-report
 
       - name: Upload report for Github Pages
         if: always()

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -68,11 +68,7 @@ jobs:
           done
 
       - name: Run e2e tests
-        run: docker compose run --rm e2e npm run test:parallel
-
-      - name: Generate report
-        if: always()
-        run: docker compose run --rm e2e npm run report
+        run: docker compose run --rm e2e npm run test:run-and-report
 
       - name: Upload report for Github Pages
         if: always()

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -68,7 +68,7 @@ jobs:
           done
 
       - name: Run e2e tests
-        run: docker compose run --rm e2e npm run test:run-and-report
+        run: docker compose run --rm -e GITHUB_REF=${{ github.ref }} -e GITHUB_SHA=${{ github.sha }} e2e npm run test:run-and-report
 
       - name: Upload report for Github Pages
         if: always()

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -29,6 +29,14 @@ jobs:
       - name: Start Oracle service
         run: ORACLE_PASSWORD=${{ secrets.ORACLE_PASSWORD_SECRET }} docker compose up -d oracle
 
+      - name: Cache node modules
+        uses: actions/cache@v3
+        with:
+          path: e2e/node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('e2e/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Install e2e dependencies
         run: npm install
         working-directory: ./e2e

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -3,6 +3,7 @@ name: E2E Tests
 on:
   workflow_call:
   workflow_dispatch:
+  pull_request:
 
 permissions:
   contents: read
@@ -22,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Start Oracle service
         run: ORACLE_PASSWORD=${{ secrets.ORACLE_PASSWORD_SECRET }} docker compose up -d oracle

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /e2e/logs
 /frontend/node_modules
 backend/.factorypath
+/e2e/metadata

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -29,7 +29,7 @@ ENV LD_LIBRARY_PATH="/opt/oracle/instantclient"
 
 RUN mvn dependency:go-offline -B
 
-RUN mvn clean package -DskipTests
+RUN mvn -B -ntp -Dmaven.repo.local=/root/.m2/repository clean package -DskipTests -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 FROM openjdk:18-jdk-slim
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "eslint . --fix",
     "test:parallel": "cucumber-js --parallel 4",
     "validate-env": "ts-node src/utils/validate-env.ts",
-    "cleanup-reports": "ts-node scripts/cleanup-reports.ts"
+    "cleanup-reports": "ts-node scripts/cleanup-reports.ts",
+    "test:run-and-report": "node ./scripts/run-tests-and-generate-report.js"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^8.11.1",

--- a/e2e/scripts/generate-report.js
+++ b/e2e/scripts/generate-report.js
@@ -86,9 +86,13 @@ function generateReport() {
       try {
         // First try to get git info from GitHub Actions environment variables
         if (process.env.GITHUB_REF && process.env.GITHUB_SHA) {
-          // GITHUB_REF is like "refs/heads/main", extract branch name
-          const refParts = process.env.GITHUB_REF.split("/");
-          gitBranch = refParts[refParts.length - 1];
+          // GITHUB_REF is like "refs/heads/main" or "refs/heads/features/report/branch-name"
+          const prefix = "refs/heads/";
+          if (process.env.GITHUB_REF.startsWith(prefix)) {
+            gitBranch = process.env.GITHUB_REF.substring(prefix.length);
+          } else {
+            gitBranch = process.env.GITHUB_REF;
+          }
           gitCommitId = process.env.GITHUB_SHA;
         } else {
           gitBranch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();

--- a/e2e/scripts/generate-report.js
+++ b/e2e/scripts/generate-report.js
@@ -51,53 +51,107 @@ function getMetadata() {
   }
 }
 
-async function generateReport() {
-  try {
-    const metadata = getMetadata();
-
-    // Get git branch and commit ID
-    let gitBranch = "unknown";
-    let gitCommitId = "unknown";
-    try {
-      gitBranch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
-      gitCommitId = execSync("git rev-parse HEAD").toString().trim();
-    } catch (error) {
-      console.warn("Failed to get git info:", error);
-    }
-
-    // Add git info to metadata
-    metadata.git = {
-      branch: gitBranch,
-      commitId: gitCommitId,
-    };
-
-    // Remove override of metadata.browser.version to avoid duplication
-    // metadata.browser.version = `${metadata.browser.name} ${metadata.browser.version}`;
-
-    reporter.generate({
-      jsonDir: path.join(__dirname, "..", "reports"),
-      reportPath: path.join(
-        __dirname,
-        "..",
-        "reports",
-        "cucumber-html-report.html"
-      ),
-      openReportInBrowser: process.env.OPEN_REPORT === "true",
-      metadata: metadata,
-      customData: {
-        title: "Additional Info",
-        data: [
-          { label: "Git Branch", value: metadata.git.branch },
-          { label: "Git Commit ID", value: metadata.git.commitId },
-          { label: "Browser", value: `${metadata.browser.name} ${metadata.browser.version}` },
-        ],
-      },
-    });
-    console.log("Report generated successfully.");
-  } catch (error) {
-    console.error("Error generating report:", error);
-    process.exit(1);
+function formatDuration(durationNs) {
+  // Convert nanoseconds to seconds with 2 decimal places
+  const seconds = durationNs / 1e9;
+  if (seconds < 60) {
+    return `${seconds.toFixed(2)} seconds`;
+  } else {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = (seconds % 60).toFixed(2);
+    return `${minutes} minutes ${remainingSeconds} seconds`;
   }
 }
+
+function generateReport() {
+  return new Promise((resolve, reject) => {
+    try {
+      const metadata = getMetadata();
+
+      // Get git branch and commit ID
+      let gitBranch = "unknown";
+      let gitCommitId = "unknown";
+      try {
+        gitBranch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
+        gitCommitId = execSync("git rev-parse HEAD").toString().trim();
+      } catch (error) {
+        console.warn("Failed to get git info:", error);
+      }
+
+      // Add git info to metadata
+      metadata.git = {
+        branch: gitBranch,
+        commitId: gitCommitId,
+      };
+
+      // Use total execution time from environment variable if provided
+      let totalExecutionTime = "unknown";
+      if (process.env.TOTAL_EXECUTION_TIME_MS) {
+        const durationMs = parseInt(process.env.TOTAL_EXECUTION_TIME_MS, 10);
+      if (!isNaN(durationMs)) {
+        totalExecutionTime = formatDuration(durationMs * 1e6);
+      }
+      } else {
+        // Calculate total execution time by summing durations in JSON report files
+        const reportsDir = path.join(__dirname, "..", "reports");
+        let totalDurationNs = 0;
+        const files = fs.readdirSync(reportsDir);
+        for (const file of files) {
+          if (file.endsWith(".json")) {
+            try {
+              const content = fs.readFileSync(path.join(reportsDir, file), "utf-8");
+              const json = JSON.parse(content);
+              if (Array.isArray(json)) {
+                for (const feature of json) {
+                  if (feature.elements) {
+                    for (const element of feature.elements) {
+                      if (element.steps) {
+                        for (const step of element.steps) {
+                          if (step.result && step.result.duration) {
+                            totalDurationNs += step.result.duration;
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            } catch (error) {
+              console.warn(`Failed to parse report file ${file}:`, error);
+            }
+          }
+        }
+        totalExecutionTime = formatDuration(totalDurationNs);
+      }
+
+      reporter.generate({
+        jsonDir: path.join(__dirname, "..", "reports"),
+        reportPath: path.join(
+          __dirname,
+          "..",
+          "reports",
+          "cucumber-html-report.html"
+        ),
+        openReportInBrowser: process.env.OPEN_REPORT === "true",
+        metadata: metadata,
+        customData: {
+          title: "Additional Info",
+          data: [
+            { label: "Git Branch", value: metadata.git.branch },
+            { label: "Git Commit ID", value: metadata.git.commitId },
+            { label: "Browser", value: `${metadata.browser.name} ${metadata.browser.version}` },
+            { label: "Total Execution Time", value: totalExecutionTime },
+          ],
+        },
+      });
+      console.log("Report generated successfully.");
+      resolve();
+    } catch (error) {
+      console.error("Error generating report:", error);
+      reject(error);
+    }
+  });
+}
+module.exports = generateReport;
 
 generateReport();

--- a/e2e/scripts/generate-report.js
+++ b/e2e/scripts/generate-report.js
@@ -65,8 +65,20 @@ function formatDuration(durationNs) {
 
 function generateReport() {
   return new Promise((resolve, reject) => {
+    const startTime = Date.now();
     try {
       const metadata = getMetadata();
+
+      function formatDateTime(timestamp) {
+        const date = new Date(timestamp);
+        const year = date.getFullYear();
+        const month = String(date.getMonth() + 1).padStart(2, "0");
+        const day = String(date.getDate()).padStart(2, "0");
+        const hours = String(date.getHours()).padStart(2, "0");
+        const minutes = String(date.getMinutes()).padStart(2, "0");
+        const seconds = String(date.getSeconds()).padStart(2, "0");
+        return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+      }
 
       // Get git branch and commit ID
       let gitBranch = "unknown";
@@ -98,9 +110,9 @@ function generateReport() {
       let totalExecutionTime = "unknown";
       if (process.env.TOTAL_EXECUTION_TIME_MS) {
         const durationMs = parseInt(process.env.TOTAL_EXECUTION_TIME_MS, 10);
-      if (!isNaN(durationMs)) {
-        totalExecutionTime = formatDuration(durationMs * 1e6);
-      }
+        if (!isNaN(durationMs)) {
+          totalExecutionTime = formatDuration(durationMs * 1e6);
+        }
       } else {
         // Calculate total execution time by summing durations in JSON report files
         const reportsDir = path.join(__dirname, "..", "reports");
@@ -139,6 +151,10 @@ function generateReport() {
         }
       }
 
+      const endTime = Date.now();
+      const reportGenerationTimeMs = endTime - startTime;
+      const reportGenerationDateTime = formatDateTime(endTime);
+
       reporter.generate({
         jsonDir: path.join(__dirname, "..", "reports"),
         reportPath: path.join(
@@ -156,10 +172,10 @@ function generateReport() {
             { label: "Git Commit ID", value: metadata.git.commitId },
             { label: "Browser", value: `${metadata.browser.name} ${metadata.browser.version}` },
             { label: "Total Execution Time", value: totalExecutionTime },
+            { label: "Report Generation Time", value: reportGenerationDateTime },
           ],
         },
       });
-      console.log("Report generated successfully.");
       resolve();
     } catch (error) {
       console.error("Error generating report:", error);

--- a/e2e/scripts/generate-report.js
+++ b/e2e/scripts/generate-report.js
@@ -71,6 +71,7 @@ function generateReport() {
 
       function formatDateTime(timestamp) {
         const date = new Date(timestamp);
+        // Use local timezone for formatting
         const year = date.getFullYear();
         const month = String(date.getMonth() + 1).padStart(2, "0");
         const day = String(date.getDate()).padStart(2, "0");
@@ -212,7 +213,7 @@ function generateReport() {
           data: [
             { label: "Git Branch", value: metadata.git.branch },
             { label: "Git Commit ID", value: metadata.git.commitId },
-            { label: "Browser", value: `${metadata.browser.name} ${metadata.browser.version}` },
+            { label: "Browser", value: `${metadata.browser.name} with version ${metadata.browser.version}` },
             { label: "Total Execution Time", value: totalExecutionTime },
             { label: "Report Generation Time", value: reportGenerationDateTime },
           ],

--- a/e2e/scripts/generate-report.js
+++ b/e2e/scripts/generate-report.js
@@ -19,6 +19,7 @@ function getMetadata() {
       browser: {
         name: envInfo.browser.name || "unknown",
         version: envInfo.browser.version || "unknown",
+        full: `${envInfo.browser.name || "unknown"} ${envInfo.browser.version || "unknown"}`,
       },
       device: envInfo.device || "unknown",
       platform: {
@@ -38,6 +39,7 @@ function getMetadata() {
       browser: {
         name: browserName,
         version: browserVersion,
+        full: `${browserName} ${browserVersion}`,
       },
       device: device,
       platform: {
@@ -50,6 +52,11 @@ function getMetadata() {
 
 async function generateReport() {
   try {
+    const metadata = getMetadata();
+
+    // Override browser.version to combined name and version string for main metadata display
+    metadata.browser.version = `${metadata.browser.name} ${metadata.browser.version}`;
+
     reporter.generate({
       jsonDir: path.join(__dirname, "..", "reports"),
       reportPath: path.join(
@@ -59,7 +66,7 @@ async function generateReport() {
         "cucumber-html-report.html"
       ),
       openReportInBrowser: process.env.OPEN_REPORT === "true",
-      metadata: getMetadata(),
+      metadata: metadata,
     });
     console.log("Report generated successfully.");
   } catch (error) {

--- a/e2e/scripts/generate-report.js
+++ b/e2e/scripts/generate-report.js
@@ -1,24 +1,51 @@
 const reporter = require("multiple-cucumber-html-reporter");
 const path = require("path");
+const fs = require("fs");
 
 function getMetadata() {
-  const browserName = process.env.BROWSER_NAME || "chrome";
-  const browserVersion = process.env.BROWSER_VERSION || "latest";
-  const device = process.env.DEVICE_NAME || "Local test machine";
-  const platformName = process.platform || "unknown";
-  const platformVersion = process.env.PLATFORM_VERSION || "unknown";
+  const envInfoPath = path.join(__dirname, "..", "metadata", "environment-info.metadata.json");
+  let envInfo = null;
 
-  return {
-    browser: {
-      name: browserName,
-      version: browserVersion,
-    },
-    device: device,
-    platform: {
-      name: platformName,
-      version: platformVersion,
-    },
-  };
+  if (fs.existsSync(envInfoPath)) {
+    try {
+      envInfo = JSON.parse(fs.readFileSync(envInfoPath, "utf-8"));
+    } catch (error) {
+      console.warn("Failed to parse environment-info.json, falling back to env vars.");
+    }
+  }
+
+  if (envInfo) {
+    return {
+      browser: {
+        name: envInfo.browser.name || "unknown",
+        version: envInfo.browser.version || "unknown",
+      },
+      device: envInfo.device || "unknown",
+      platform: {
+        name: envInfo.platform.name || "unknown",
+        version: envInfo.platform.version || "unknown",
+      },
+    };
+  } else {
+    // Fallback to environment variables
+    const browserName = process.env.BROWSER_NAME || "chrome";
+    const browserVersion = process.env.BROWSER_VERSION || "latest";
+    const device = process.env.DEVICE_NAME || "Local test machine";
+    const platformName = process.platform || "unknown";
+    const platformVersion = process.env.PLATFORM_VERSION || "unknown";
+
+    return {
+      browser: {
+        name: browserName,
+        version: browserVersion,
+      },
+      device: device,
+      platform: {
+        name: platformName,
+        version: platformVersion,
+      },
+    };
+  }
 }
 
 async function generateReport() {

--- a/e2e/scripts/run-tests-and-generate-report.js
+++ b/e2e/scripts/run-tests-and-generate-report.js
@@ -26,11 +26,15 @@ function runTests() {
 
 async function main() {
   const startTime = Date.now();
+  let totalExecutionTimeMs = 0;
   try {
     await runTests();
+  } catch (error) {
+    console.error("Test run failed:", error);
+  } finally {
     const endTime = Date.now();
-    const totalExecutionTimeMs = endTime - startTime;
-    console.log(`totalExecutionTimeMs: `, totalExecutionTimeMs)
+    totalExecutionTimeMs = endTime - startTime;
+    console.log(`totalExecutionTimeMs: `, totalExecutionTimeMs);
 
     // Pass totalExecutionTimeMs to generate-report.js
     // We will modify generate-report.js to accept this as an environment variable
@@ -46,9 +50,6 @@ async function main() {
       console.error("generate-report.js does not export a callable function");
       process.exit(1);
     }
-  } catch (error) {
-    console.error("Error running tests or generating report:", error);
-    process.exit(1);
   }
 }
 

--- a/e2e/scripts/run-tests-and-generate-report.js
+++ b/e2e/scripts/run-tests-and-generate-report.js
@@ -1,10 +1,11 @@
 const { exec } = require("child_process");
 const path = require("path");
-const reporter = require("./generate-report");
 
 function runTests() {
   return new Promise((resolve, reject) => {
-    const testProcess = exec("npm run test:parallel", { cwd: path.join(__dirname, "..") });
+    const testProcess = exec("npm run test:parallel", {
+      cwd: path.join(__dirname, ".."),
+    });
 
     testProcess.stdout.on("data", (data) => {
       process.stdout.write(data);

--- a/e2e/scripts/run-tests-and-generate-report.js
+++ b/e2e/scripts/run-tests-and-generate-report.js
@@ -1,0 +1,55 @@
+const { exec } = require("child_process");
+const path = require("path");
+const reporter = require("./generate-report");
+
+function runTests() {
+  return new Promise((resolve, reject) => {
+    const testProcess = exec("npm run test:parallel", { cwd: path.join(__dirname, "..") });
+
+    testProcess.stdout.on("data", (data) => {
+      process.stdout.write(data);
+    });
+
+    testProcess.stderr.on("data", (data) => {
+      process.stderr.write(data);
+    });
+
+    testProcess.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Test process exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function main() {
+  const startTime = Date.now();
+  try {
+    await runTests();
+    const endTime = Date.now();
+    const totalExecutionTimeMs = endTime - startTime;
+    console.log(`totalExecutionTimeMs: `, totalExecutionTimeMs)
+
+    // Pass totalExecutionTimeMs to generate-report.js
+    // We will modify generate-report.js to accept this as an environment variable
+    process.env.TOTAL_EXECUTION_TIME_MS = totalExecutionTimeMs.toString();
+
+    // Import and run generate-report.js main function
+    const generateReport = require("./generate-report");
+    if (typeof generateReport === "function") {
+      await generateReport();
+    } else if (generateReport.generateReport) {
+      await generateReport.generateReport();
+    } else {
+      console.error("generate-report.js does not export a callable function");
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error("Error running tests or generating report:", error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/e2e/src/hooks/before.hooks.ts
+++ b/e2e/src/hooks/before.hooks.ts
@@ -4,6 +4,9 @@ import { CustomWorld } from "../support/world";
 import { logger } from "../support/logger";
 import { CategoryPage } from "../pages/category.page";
 
+import * as fs from "fs";
+import * as path from "path";
+
 Before(async function (this: CustomWorld, { pickle }) {
   logger.info(
     `Before scenario: Launching browser for scenario "${pickle.name}"`
@@ -19,5 +22,22 @@ Before(async function (this: CustomWorld, { pickle }) {
       const text = msg.text();
       logger.info(`Browser console [${type}] [${pickle.name}]: ${text}`);
     });
+  }
+
+  // Save environment info to JSON file for report metadata
+  try {
+    const envInfo = await this.getEnvironmentInfo();
+    const reportsDir = path.join(__dirname, "..", "..", "metadata");
+    if (!fs.existsSync(reportsDir)) {
+      fs.mkdirSync(reportsDir, { recursive: true });
+    }
+    if (!fs.existsSync(reportsDir)) {
+      fs.mkdirSync(reportsDir, { recursive: true });
+    }
+    const envInfoPath = path.join(reportsDir, "environment-info.metadata.json");
+    fs.writeFileSync(envInfoPath, JSON.stringify(envInfo, null, 2), "utf-8");
+    logger.info(`Environment info saved to ${envInfoPath}`);
+  } catch (error) {
+    logger.error("Failed to save environment info:", error);
   }
 });

--- a/e2e/src/hooks/before.hooks.ts
+++ b/e2e/src/hooks/before.hooks.ts
@@ -1,11 +1,10 @@
 import { Before } from "@cucumber/cucumber";
+import * as fs from "fs";
+import * as path from "path";
 
 import { CustomWorld } from "../support/world";
 import { logger } from "../support/logger";
 import { CategoryPage } from "../pages/category.page";
-
-import * as fs from "fs";
-import * as path from "path";
 
 Before(async function (this: CustomWorld, { pickle }) {
   logger.info(

--- a/e2e/src/support/global-teardown.ts
+++ b/e2e/src/support/global-teardown.ts
@@ -3,14 +3,22 @@ import * as fs from "fs";
 import * as path from "path";
 
 async function getMetadata() {
-  const envInfoPath = path.join(__dirname, "..", "..", "metadata", "environment-info.metadata.json");
+  const envInfoPath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "metadata",
+    "environment-info.metadata.json"
+  );
   let envInfo = null;
 
   if (fs.existsSync(envInfoPath)) {
     try {
       envInfo = JSON.parse(fs.readFileSync(envInfoPath, "utf-8"));
     } catch (error) {
-      console.warn("Failed to parse environment-info.metadata.json, falling back to defaults.");
+      console.warn(
+        "Failed to parse environment-info.metadata.json, falling back to defaults."
+      );
     }
   }
 

--- a/e2e/src/support/global-teardown.ts
+++ b/e2e/src/support/global-teardown.ts
@@ -1,30 +1,64 @@
 import { generate } from "multiple-cucumber-html-reporter";
+import * as fs from "fs";
+import * as path from "path";
 
-import { config } from "../config/env.config";
+async function getMetadata() {
+  const envInfoPath = path.join(__dirname, "..", "..", "metadata", "environment-info.metadata.json");
+  let envInfo = null;
 
-generate({
-  jsonDir: "reports",
-  reportPath: "reports/cucumber-html-report.html",
-  metadata: {
-    browser: {
-      name: config.browser.name,
-      version: "latest",
+  if (fs.existsSync(envInfoPath)) {
+    try {
+      envInfo = JSON.parse(fs.readFileSync(envInfoPath, "utf-8"));
+    } catch (error) {
+      console.warn("Failed to parse environment-info.metadata.json, falling back to defaults.");
+    }
+  }
+
+  if (envInfo) {
+    return {
+      browser: {
+        name: envInfo.browser.name || "unknown",
+        version: envInfo.browser.version || "unknown",
+      },
+      device: envInfo.device || "unknown",
+      platform: {
+        name: envInfo.platform.name || "unknown",
+        version: envInfo.platform.version || "unknown",
+      },
+    };
+  } else {
+    return {
+      browser: {
+        name: "unknown",
+        version: "unknown",
+      },
+      device: "unknown",
+      platform: {
+        name: process.platform,
+        version: process.version,
+      },
+    };
+  }
+}
+
+(async () => {
+  const metadata = await getMetadata();
+
+  generate({
+    jsonDir: "reports",
+    reportPath: "reports/cucumber-html-report.html",
+    metadata: metadata,
+    customData: {
+      title: "Run Info",
+      data: [
+        { label: "Project", value: "Money Keeper E2E Tests" },
+        { label: "Environment", value: "Local" },
+      ],
     },
-    platform: {
-      name: process.platform,
-      version: process.version,
-    },
-  },
-  customData: {
-    title: "Run Info",
-    data: [
-      { label: "Project", value: "Money Keeper E2E Tests" },
-      { label: "Environment", value: config.browser.baseUrl },
-    ],
-  },
-  displayDuration: true,
-  durationInMS: true,
-  displayReportTime: true,
-  pageTitle: "Money Keeper Test Report",
-  reportName: "Money Keeper E2E Test Results",
-});
+    displayDuration: true,
+    durationInMS: true,
+    displayReportTime: true,
+    pageTitle: "Money Keeper Test Report",
+    reportName: "Money Keeper E2E Test Results",
+  });
+})();

--- a/e2e/src/support/world.ts
+++ b/e2e/src/support/world.ts
@@ -72,9 +72,9 @@ export class CustomWorld extends World {
     const userAgent = this.page ? await this.page.evaluate(() => navigator.userAgent) : "unknown";
 
     // Simple parsing of userAgent to get platform and device type
-    let deviceType = "desktop";
+    let deviceType = "Desktop";
     if (/Mobi|Android/i.test(userAgent)) {
-      deviceType = "smart device";
+      deviceType = "Smart Device";
     }
 
     // Extract platform name and version from userAgent (basic)

--- a/e2e/src/support/world.ts
+++ b/e2e/src/support/world.ts
@@ -68,8 +68,12 @@ export class CustomWorld extends World {
   }
 
   async getEnvironmentInfo() {
-    const browserVersion = this.browser ? await this.browser.version() : "unknown";
-    const userAgent = this.page ? await this.page.evaluate(() => navigator.userAgent) : "unknown";
+    const browserVersion = this.browser
+      ? await this.browser.version()
+      : "unknown";
+    const userAgent = this.page
+      ? await this.page.evaluate(() => navigator.userAgent)
+      : "unknown";
 
     // Simple parsing of userAgent to get platform and device type
     let deviceType = "Desktop";

--- a/e2e/src/support/world.ts
+++ b/e2e/src/support/world.ts
@@ -66,6 +66,46 @@ export class CustomWorld extends World {
       throw error;
     }
   }
+
+  async getEnvironmentInfo() {
+    const browserVersion = this.browser ? await this.browser.version() : "unknown";
+    const userAgent = this.page ? await this.page.evaluate(() => navigator.userAgent) : "unknown";
+
+    // Simple parsing of userAgent to get platform and device type
+    let deviceType = "desktop";
+    if (/Mobi|Android/i.test(userAgent)) {
+      deviceType = "smart device";
+    }
+
+    // Extract platform name and version from userAgent (basic)
+    let platformName = "unknown";
+    let platformVersion = "unknown";
+    const platformMatch = userAgent.match(/\(([^)]+)\)/);
+    if (platformMatch && platformMatch[1]) {
+      const platformInfo = platformMatch[1].split(";");
+      if (platformInfo.length > 0) {
+        platformName = platformInfo[0].trim();
+        if (platformInfo.length > 1) {
+          platformVersion = platformInfo[1].trim();
+        }
+      }
+    }
+
+    // Browser name from config or fallback
+    const browserName = config.browser.name || "unknown";
+
+    return {
+      browser: {
+        name: browserName,
+        version: browserVersion,
+      },
+      device: deviceType,
+      platform: {
+        name: platformName,
+        version: platformVersion,
+      },
+    };
+  }
 }
 
 setWorldConstructor(CustomWorld);


### PR DESCRIPTION
Adds logic to capture and persist environment information (browser, device, platform) during E2E test runs. The metadata is saved to a JSON file and integrated into the HTML report, improving traceability and context for test results. Updates .gitignore to exclude the new metadata directory.